### PR TITLE
set VAULT_ADDR protocol based on tls_disable configuration

### DIFF
--- a/vault/hooks/run
+++ b/vault/hooks/run
@@ -12,7 +12,7 @@ then
 else
   # Set variables
   UNSEAL_KEYS=({{#each cfg.unseal_keys as |key| ~}}"{{key}}"{{#unless @last}} {{/unless}}{{/each}})
-  export VAULT_ADDR="http://{{cfg.listener.location}}:{{cfg.listener.port}}"
+  export VAULT_ADDR="{{#unless cfg.listener.tls_disable ~}}https{{/unless}}{{#if cfg.listener.tls_disable ~}}http{{/if}}://{{cfg.listener.location}}:{{cfg.listener.port}}"
   export VAULT_TOKEN="{{cfg.token}}"
 
   # Shortcut to determine if this is the leader in a leader-follower topology


### PR DESCRIPTION
Same strategy as we use here:

https://github.com/Indellient/liftoff-modern-application-automation/blob/9c426dd95c7cdeaf0ff232a4b13b01e64b4d438e/habitat-plans/vault/hooks/run#L19